### PR TITLE
Add server logs monitoring page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const NewSubscription = lazy(() => import("./pages/NewSubscription"));
 const UsersPage = lazy(() => import("./pages/Users"));
 const Analytics = lazy(() => import("./pages/Analytics"));
 const Support = lazy(() => import("./pages/Support"));
+const Logs = lazy(() => import("./pages/Logs"));
 const Settings = lazy(() => import("./pages/Settings"));
 const Landing = lazy(() => import("./pages/Landing"));
 const Login = lazy(() => import("./pages/Login"));
@@ -59,6 +60,7 @@ const App = () => {
                 <Route path={adminRelativePath.newUser} element={<NewUser />} />
                 <Route path={adminRelativePath.analytics} element={<Analytics />} />
                 <Route path={adminRelativePath.support} element={<Support />} />
+                <Route path={adminRelativePath.logs} element={<Logs />} />
                 <Route path={adminRelativePath.settings} element={<Settings />} />
               </Route>
               <Route path={routes.home} element={<Landing />} />

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -17,6 +17,7 @@ import {
   Users,
   BarChart3,
   HeadphonesIcon,
+  FileText,
   Settings
 } from "lucide-react";
 import { Link } from "react-router-dom";
@@ -58,6 +59,11 @@ const navigation = [
     name: "Suporte",
     href: routes.admin.support,
     icon: HeadphonesIcon,
+  },
+  {
+    name: "Logs",
+    href: routes.admin.logs,
+    icon: FileText,
   },
   {
     name: "Configurações",

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -20,6 +20,7 @@ export const routes = {
     newUser: route(buildAdminPath("users", "new")),
     analytics: route(buildAdminPath("analytics")),
     support: route(buildAdminPath("support")),
+    logs: route(buildAdminPath("logs")),
     settings: route(buildAdminPath("settings")),
   },
   notFound: route("*"),
@@ -46,5 +47,6 @@ export const adminRelativePath = {
   newUser: "users/new",
   analytics: "analytics",
   support: "support",
+  logs: "logs",
   settings: "settings",
 } as const;

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -297,3 +297,178 @@ export const mockPlanDistribution = [
   { name: 'Profissional', value: 35, customers: 8 },
   { name: 'Enterprise', value: 25, customers: 7 },
 ];
+
+export interface ServerLog {
+  id: string;
+  level: 'info' | 'warn' | 'error';
+  timestamp: string;
+  message: string;
+  logger?: string;
+  metadata?: Record<string, unknown>;
+  request?: {
+    method: string;
+    host: string;
+    uri: string;
+    status: number;
+    durationMs: number;
+    size: number;
+    clientIp: string;
+    protocol: string;
+    userAgent: string;
+    forwardedFor?: string;
+  };
+}
+
+export const mockServerLogs: ServerLog[] = [
+  {
+    id: 'log-1',
+    level: 'info',
+    timestamp: '2025-09-15T17:07:15.296242+00:00',
+    message: 'Using config from file',
+    metadata: {
+      file: '/assets/Caddyfile',
+    },
+  },
+  {
+    id: 'log-2',
+    level: 'info',
+    timestamp: '2025-09-15T17:07:15.301657+00:00',
+    message: 'Adapted config to JSON',
+    metadata: {
+      adapter: 'caddyfile',
+    },
+  },
+  {
+    id: 'log-3',
+    level: 'warn',
+    timestamp: '2025-09-15T17:07:15.302323+00:00',
+    logger: 'admin',
+    message: 'Admin endpoint disabled',
+    metadata: {
+      admin_endpoint: 'disabled',
+    },
+  },
+  {
+    id: 'log-4',
+    level: 'info',
+    timestamp: '2025-09-15T17:07:15.302607+00:00',
+    logger: 'http.auto_https',
+    message: 'Automatic HTTPS is completely disabled for server',
+    metadata: {
+      server_name: 'srv0',
+    },
+  },
+  {
+    id: 'log-5',
+    level: 'info',
+    timestamp: '2025-09-15T17:07:15.306016+00:00',
+    logger: 'http.log',
+    message: 'Server running',
+    metadata: {
+      name: 'srv0',
+      protocols: ['h1', 'h2', 'h3'],
+    },
+  },
+  {
+    id: 'log-6',
+    level: 'info',
+    timestamp: '2025-09-15T17:07:15.306064+00:00',
+    message: 'Serving initial configuration',
+  },
+  {
+    id: 'log-7',
+    level: 'info',
+    timestamp: '2025-09-15T17:07:15.306252+00:00',
+    logger: 'tls.cache.maintenance',
+    message: 'Started background certificate maintenance',
+    metadata: {
+      cache: '0xc00080e500',
+    },
+  },
+  {
+    id: 'log-8',
+    level: 'info',
+    timestamp: '2025-09-15T17:07:15.346178+00:00',
+    logger: 'tls',
+    message: 'Cleaning storage unit',
+    metadata: {
+      storage: 'FileStorage:/root/.local/share/caddy',
+    },
+  },
+  {
+    id: 'log-9',
+    level: 'info',
+    timestamp: '2025-09-15T17:07:15.346889+00:00',
+    logger: 'tls',
+    message: 'Finished cleaning storage units',
+  },
+  {
+    id: 'log-10',
+    level: 'info',
+    timestamp: '2025-09-15T17:10:23.929662+00:00',
+    logger: 'http.log.access.log0',
+    message: 'Handled request',
+    metadata: {
+      referer: 'https://easypanel02.quantumtecnologia.com.br/',
+    },
+    request: {
+      method: 'GET',
+      host: 'quantumtecnologia-jus-conennect-admin.3a2ucf.easypanel.host',
+      uri: '/',
+      status: 200,
+      durationMs: 20.37,
+      size: 380,
+      clientIp: '190.52.73.117',
+      protocol: 'HTTP/1.1',
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36',
+      forwardedFor: '190.52.73.117',
+    },
+  },
+  {
+    id: 'log-11',
+    level: 'info',
+    timestamp: '2025-09-15T17:16:24.800494+00:00',
+    logger: 'http.log.access.log0',
+    message: 'Handled request',
+    metadata: {
+      cache_control: 'max-age=0',
+    },
+    request: {
+      method: 'GET',
+      host: 'quantumtecnologia-jus-conennect-admin.3a2ucf.easypanel.host',
+      uri: '/',
+      status: 304,
+      durationMs: 1.35,
+      size: 0,
+      clientIp: '190.52.73.117',
+      protocol: 'HTTP/1.1',
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36',
+      forwardedFor: '190.52.73.117',
+    },
+  },
+  {
+    id: 'log-12',
+    level: 'info',
+    timestamp: '2025-09-15T17:16:25.575566+00:00',
+    logger: 'http.log.access.log0',
+    message: 'Handled request',
+    metadata: {
+      cache_control: 'max-age=0',
+    },
+    request: {
+      method: 'GET',
+      host: 'quantumtecnologia-jus-conennect-admin.3a2ucf.easypanel.host',
+      uri: '/',
+      status: 304,
+      durationMs: 0.31,
+      size: 0,
+      clientIp: '190.52.73.117',
+      protocol: 'HTTP/1.1',
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36',
+      forwardedFor: '190.52.73.117',
+    },
+  },
+];

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -1,0 +1,392 @@
+import { useMemo, useState } from "react";
+import { Activity, AlertTriangle, Search as SearchIcon, Server, Timer } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { mockServerLogs, type ServerLog } from "@/data/mockData";
+import { cn } from "@/lib/utils";
+
+type LevelFilter = "all" | ServerLog["level"];
+
+const levelLabels: Record<ServerLog["level"], string> = {
+  info: "Info",
+  warn: "Alerta",
+  error: "Erro",
+};
+
+const levelBadgeStyles: Record<ServerLog["level"], string> = {
+  info: "border-blue-200 bg-blue-100 text-blue-800 dark:border-blue-400/30 dark:bg-blue-500/10 dark:text-blue-200",
+  warn: "border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-400/30 dark:bg-amber-500/10 dark:text-amber-100",
+  error: "border-red-200 bg-red-100 text-red-800 dark:border-red-400/30 dark:bg-red-500/10 dark:text-red-100",
+};
+
+const getStatusBadgeClass = (status: number) => {
+  if (status >= 500) {
+    return "border-red-200 bg-red-100 text-red-800 dark:border-red-400/30 dark:bg-red-500/10 dark:text-red-100";
+  }
+
+  if (status >= 400) {
+    return "border-orange-200 bg-orange-100 text-orange-800 dark:border-orange-400/30 dark:bg-orange-500/10 dark:text-orange-100";
+  }
+
+  if (status >= 300) {
+    return "border-amber-200 bg-amber-100 text-amber-800 dark:border-amber-400/30 dark:bg-amber-500/10 dark:text-amber-100";
+  }
+
+  return "border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-400/30 dark:bg-emerald-500/10 dark:text-emerald-100";
+};
+
+const formatDateTime = (timestamp: string) =>
+  new Date(timestamp).toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "medium" });
+
+const formatDuration = (durationMs: number) => {
+  if (durationMs >= 1000) {
+    return `${(durationMs / 1000).toFixed(2)} s`;
+  }
+
+  if (durationMs >= 100) {
+    return `${durationMs.toFixed(0)} ms`;
+  }
+
+  if (durationMs >= 10) {
+    return `${durationMs.toFixed(1)} ms`;
+  }
+
+  if (durationMs >= 1) {
+    return `${durationMs.toFixed(2)} ms`;
+  }
+
+  return `${durationMs.toFixed(3)} ms`;
+};
+
+const buildMetadataSummary = (log: ServerLog) => {
+  if (!log.metadata) {
+    return null;
+  }
+
+  const entries = Object.entries(log.metadata).map(([key, value]) => {
+    if (Array.isArray(value)) {
+      return `${key}: ${value.join(", ")}`;
+    }
+
+    if (typeof value === "object" && value !== null) {
+      return `${key}: ${JSON.stringify(value)}`;
+    }
+
+    return `${key}: ${value}`;
+  });
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return entries.slice(0, 2).join(" • ");
+};
+
+const Logs = () => {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [levelFilter, setLevelFilter] = useState<LevelFilter>("all");
+
+  const sortedLogs = useMemo(
+    () =>
+      [...mockServerLogs].sort(
+        (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+      ),
+    [],
+  );
+
+  const stats = useMemo(() => {
+    let info = 0;
+    let warn = 0;
+    let error = 0;
+    let httpCount = 0;
+    let totalDuration = 0;
+    const uniqueIps = new Set<string>();
+
+    sortedLogs.forEach((log) => {
+      if (log.level === "info") info += 1;
+      if (log.level === "warn") warn += 1;
+      if (log.level === "error") error += 1;
+
+      if (log.request) {
+        httpCount += 1;
+        totalDuration += log.request.durationMs;
+        uniqueIps.add(log.request.clientIp);
+      }
+    });
+
+    return {
+      total: sortedLogs.length,
+      info,
+      warn,
+      error,
+      alerts: warn + error,
+      httpCount,
+      avgDuration: httpCount ? totalDuration / httpCount : 0,
+      uniqueClients: uniqueIps.size,
+      lastTimestamp: sortedLogs[0]?.timestamp,
+    };
+  }, [sortedLogs]);
+
+  const filteredLogs = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return sortedLogs.filter((log) => {
+      if (levelFilter !== "all" && log.level !== levelFilter) {
+        return false;
+      }
+
+      if (!normalizedSearch) {
+        return true;
+      }
+
+      const haystackParts = [
+        log.message,
+        log.logger,
+        log.request?.method,
+        log.request?.uri,
+        log.request ? String(log.request.status) : undefined,
+        log.request?.clientIp,
+        log.request?.host,
+        log.request?.userAgent,
+        log.metadata ? JSON.stringify(log.metadata) : undefined,
+      ];
+
+      return haystackParts
+        .filter((part): part is string => typeof part === "string")
+        .some((part) => part.toLowerCase().includes(normalizedSearch));
+    });
+  }, [levelFilter, searchTerm, sortedLogs]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold">Monitoramento de Logs</h1>
+        <p className="text-muted-foreground">
+          Acompanhe eventos do servidor Caddy e requisições HTTP realizadas na aplicação.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total de registros</CardTitle>
+            <Activity className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.total}</div>
+            {stats.lastTimestamp ? (
+              <p className="text-xs text-muted-foreground">
+                Último evento: {formatDateTime(stats.lastTimestamp)}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">Sem registros recentes</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Alertas</CardTitle>
+            <AlertTriangle className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.alerts}</div>
+            <p className="text-xs text-muted-foreground">
+              {stats.warn} avisos • {stats.error} erros
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Requisições HTTP</CardTitle>
+            <Server className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.httpCount}</div>
+            <p className="text-xs text-muted-foreground">
+              IPs monitorados: {stats.uniqueClients}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Tempo médio de resposta</CardTitle>
+            <Timer className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {stats.httpCount ? formatDuration(stats.avgDuration) : "—"}
+            </div>
+            <p className="text-xs text-muted-foreground">Baseado em requisições registradas</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="space-y-4">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-col gap-1">
+              <CardTitle>Registros recentes</CardTitle>
+              <CardDescription>Filtre por nível ou procure termos específicos nos eventos.</CardDescription>
+            </div>
+            <Badge variant="outline" className="self-start bg-muted text-xs font-normal text-muted-foreground md:self-center">
+              {filteredLogs.length} registro{filteredLogs.length === 1 ? "" : "s"}
+            </Badge>
+          </div>
+
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="relative w-full md:max-w-xs">
+              <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Buscar por mensagem, IP ou status..."
+                className="pl-9"
+              />
+            </div>
+            <div className="flex w-full gap-2 md:w-auto">
+              <Select value={levelFilter} onValueChange={(value) => setLevelFilter(value as LevelFilter)}>
+                <SelectTrigger className="md:w-[200px]">
+                  <SelectValue placeholder="Filtrar por nível" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos os níveis</SelectItem>
+                  <SelectItem value="info">Informações</SelectItem>
+                  <SelectItem value="warn">Alertas</SelectItem>
+                  <SelectItem value="error">Erros</SelectItem>
+                </SelectContent>
+              </Select>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setSearchTerm("");
+                  setLevelFilter("all");
+                }}
+                disabled={!searchTerm && levelFilter === "all"}
+              >
+                Limpar filtros
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="min-w-[180px]">Horário</TableHead>
+                  <TableHead className="min-w-[120px]">Nível</TableHead>
+                  <TableHead className="min-w-[200px]">Origem</TableHead>
+                  <TableHead className="min-w-[220px]">Mensagem</TableHead>
+                  <TableHead className="min-w-[240px]">Detalhes</TableHead>
+                  <TableHead className="text-right">Ações</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredLogs.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="py-10 text-center text-sm text-muted-foreground">
+                      Nenhum registro encontrado com os filtros atuais.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filteredLogs.map((log) => {
+                    const metadataSummary = buildMetadataSummary(log);
+
+                    return (
+                      <TableRow key={log.id}>
+                        <TableCell>
+                          <div className="font-medium">{formatDateTime(log.timestamp)}</div>
+                          {log.request ? (
+                            <div className="text-xs text-muted-foreground">{formatDuration(log.request.durationMs)}</div>
+                          ) : null}
+                        </TableCell>
+                        <TableCell>
+                          <Badge className={cn("w-fit", levelBadgeStyles[log.level])}>
+                            {levelLabels[log.level]}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex flex-col gap-1">
+                            <span className="font-medium">{log.logger ?? "Aplicação"}</span>
+                            {log.request ? (
+                              <span className="text-xs text-muted-foreground">{log.request.host}</span>
+                            ) : null}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="font-medium">{log.message}</div>
+                          {metadataSummary ? (
+                            <p className="text-xs text-muted-foreground">{metadataSummary}</p>
+                          ) : null}
+                        </TableCell>
+                        <TableCell>
+                          {log.request ? (
+                            <div className="space-y-1 text-xs">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <Badge className={cn("w-fit", getStatusBadgeClass(log.request.status))}>
+                                  {log.request.status}
+                                </Badge>
+                                <span className="font-medium text-foreground">
+                                  {log.request.method} {log.request.uri}
+                                </span>
+                              </div>
+                              <div className="text-muted-foreground">
+                                {log.request.clientIp} • {log.request.protocol}
+                              </div>
+                            </div>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">Sem detalhes adicionais</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Dialog>
+                            <DialogTrigger asChild>
+                              <Button variant="outline" size="sm">
+                                Ver detalhes
+                              </Button>
+                            </DialogTrigger>
+                            <DialogContent className="max-w-2xl">
+                              <DialogHeader>
+                                <DialogTitle>Detalhes do log</DialogTitle>
+                                <DialogDescription>
+                                  Evento registrado em {formatDateTime(log.timestamp)}
+                                </DialogDescription>
+                              </DialogHeader>
+                              <div className="rounded-md bg-muted p-4 text-left text-xs">
+                                <pre className="max-h-[400px] overflow-auto whitespace-pre-wrap">
+                                  {JSON.stringify(log, null, 2)}
+                                </pre>
+                              </div>
+                            </DialogContent>
+                          </Dialog>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Logs;


### PR DESCRIPTION
## Summary
- add a dedicated Logs route to the admin router and sidebar navigation
- model mock server log entries based on Caddy output for use across the app
- build a monitoring page with filters, stats, and detailed views for each log entry

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c84a0d90788326bda130291e31972a