### PR TITLE
fix: use relative asset base for build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,19 +6,22 @@ import { componentTagger } from "lovable-tagger";
 // https://vitejs.dev/config/
 const normalizeBasePath = (value?: string) => {
   if (!value) {
-    return "/";
+    return "./";
   }
 
   const trimmed = value.trim();
   if (!trimmed) {
-    return "/";
+    return "./";
   }
 
-  if (trimmed === "/") {
-    return trimmed;
+  if (trimmed === "." || trimmed === "./") {
+    return "./";
   }
 
-  return trimmed.startsWith("/") ? trimmed.replace(/\/+$/, "") : `/${trimmed.replace(/\/+$/, "")}`;
+  const normalized = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  const withoutTrailingSlash = normalized.replace(/\/+$/, "");
+
+  return `${withoutTrailingSlash}/`;
 };
 
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
## Summary
- normalize the Vite base path to default to a relative `./` value so built assets load when served statically
- ensure custom base paths retain a trailing slash for consistent asset resolution in production

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c84ee1a6dc8326b8f468f4352cebfc