### PR TITLE
Fix base path normalization for router configuration

### DIFF
--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -38,7 +38,16 @@ const normalizePath = (value: string | undefined, fallback: string) => {
     return fallback;
   }
 
-  const withLeadingSlash = sanitized.startsWith("/") ? sanitized : `/${sanitized}`;
+  const withoutRelativePrefix = sanitized.replace(/^\.\/+/u, "");
+
+  if (withoutRelativePrefix.length === 0 || withoutRelativePrefix === ".") {
+    return "/";
+  }
+
+  const withLeadingSlash = withoutRelativePrefix.startsWith("/")
+    ? withoutRelativePrefix
+    : `/${withoutRelativePrefix}`;
+
   if (withLeadingSlash.length === 1) {
     return withLeadingSlash;
   }


### PR DESCRIPTION
## Summary
- normalize app-config paths to treat relative values like ./ as the root path
- ensure the computed basename stays valid for BrowserRouter when VITE_APP_BASE_PATH uses relative notation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c852965d388326996151bd8cfa6cc5