### PR TITLE
Handle production bundle loading via manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Simply open [Lovable](https://lovable.dev/projects/9189a249-3d12-4c39-8dc9-26826
 2. Garanta que `VITE_APP_BASE_PATH` e `VITE_ADMIN_BASE_PATH` correspondam aos caminhos públicos onde a aplicação será servida.
 3. Atualize `VITE_API_BASE_URL` com o endpoint real da API que será consumida em produção.
 4. Execute `npm run build` para gerar os artefatos minificados na pasta `dist/`.
-5. Opcionalmente, rode `npm run preview` para validar o comportamento do bundle antes de fazer o deploy definitivo.
+5. Ao publicar em um servidor estático, garanta que `dist/manifest.json` e a pasta `dist/assets/` estejam disponíveis no mesmo nível do `index.html` servido (ou simplesmente aponte o servidor para a pasta `dist/`).
+6. Opcionalmente, rode `npm run preview` para validar o comportamento do bundle antes de fazer o deploy definitivo.
 
 ## Can I connect a custom domain to my Lovable project?
 

--- a/index.html
+++ b/index.html
@@ -19,6 +19,105 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module">
+      const resolvePublicPath = (path) => {
+        if (!path) {
+          return null;
+        }
+
+        if (/^https?:/u.test(path)) {
+          return path;
+        }
+
+        if (path.startsWith("/")) {
+          return path;
+        }
+
+        return `./${path}`;
+      };
+
+      const ensureStylesheets = (files = []) =>
+        Promise.all(
+          files.map((file) => {
+            const href = resolvePublicPath(file);
+            if (!href) {
+              return Promise.resolve();
+            }
+
+            if (document.querySelector(`link[rel="stylesheet"][href="${href}"]`)) {
+              return Promise.resolve();
+            }
+
+            return new Promise((resolve, reject) => {
+              const link = document.createElement("link");
+              link.rel = "stylesheet";
+              link.href = href;
+              link.onload = () => resolve(undefined);
+              link.onerror = () => reject(new Error(`Não foi possível carregar ${href}`));
+              document.head.appendChild(link);
+            });
+          }),
+        );
+
+      const loadFromManifest = async () => {
+        try {
+          const manifestUrl = new URL("./manifest.json", window.location.href);
+          const response = await fetch(manifestUrl, { cache: "no-store" });
+          if (!response.ok) {
+            return false;
+          }
+
+          const manifest = await response.json();
+          const entry = manifest["index.html"] ?? manifest["src/main.tsx"];
+          if (!entry?.file) {
+            return false;
+          }
+
+          const styles = new Set(entry.css ?? []);
+          if (entry.dynamicImports) {
+            entry.dynamicImports
+              .map((key) => manifest[key])
+              .filter((item) => Array.isArray(item?.css))
+              .forEach((item) => item.css.forEach((cssFile) => styles.add(cssFile)));
+          }
+
+          await ensureStylesheets([...styles]).catch((error) => {
+            console.warn("Falha ao carregar estilos do bundle", error);
+          });
+
+          const entryPath = resolvePublicPath(entry.file);
+          if (!entryPath) {
+            return false;
+          }
+
+          await import(/* @vite-ignore */ entryPath);
+          return true;
+        } catch (error) {
+          console.warn("Não foi possível carregar o bundle gerado pelo build", error);
+          return false;
+        }
+      };
+
+      const startApplication = async () => {
+        const loaded = await loadFromManifest();
+        if (loaded) {
+          return;
+        }
+
+        await import("/src/main.tsx");
+      };
+
+      startApplication().catch((error) => {
+        console.error("Falha ao iniciar a aplicação", error);
+        const root = document.getElementById("root");
+        if (root) {
+          root.innerHTML =
+            '<div style="padding: 1.5rem; font-family: system-ui, sans-serif; color: #dc2626;">' +
+            "<h1 style=\"font-size: 1.25rem; margin-bottom: 0.5rem;\">Não foi possível carregar a aplicação</h1>" +
+            "<p style=\"margin: 0;\">Verifique se o build foi executado e se o arquivo <code>manifest.json</code> está disponível.</p>" +
+            "</div>";
+        }
+      });
+    </script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig(({ mode }) => {
     build: {
       sourcemap: mode !== "production",
       chunkSizeWarningLimit: 1024,
+      manifest: "manifest.json",
     },
   };
 });


### PR DESCRIPTION
## Summary
- load the SPA bundle at runtime by reading the Vite manifest when it is available and fall back to the dev entry when it is not
- generate `manifest.json` during builds so static deployments can expose the hashed assets alongside the existing `index.html`
- document the need to publish the generated manifest and assets when serving the app from a static server

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9abf53fd483268717c04bafb65212