### PR TITLE
Improve bootstrap logic for production builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,38 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module">
+      const loadAppFromManifest = async () => {
+        const manifestUrl = new URL("./manifest.json", window.location.href);
+
+        try {
+          const response = await fetch(manifestUrl, { cache: "no-cache" });
+          if (!response.ok) {
+            throw new Error(`Manifest request failed with status ${response.status}`);
+          }
+
+          const manifest = await response.json();
+          const entry =
+            manifest["src/main.tsx"] ??
+            manifest["src/main.ts"] ??
+            manifest["src/main.jsx"] ??
+            manifest["src/main.js"];
+
+          if (!entry?.file) {
+            throw new Error("Could not find an entry chunk in manifest.json");
+          }
+
+          const entryUrl = new URL(entry.file, manifestUrl);
+          await import(entryUrl.href);
+        } catch (error) {
+          console.warn("Falling back to Vite dev server entry:", error);
+          await import("/src/main.tsx");
+        }
+      };
+
+      loadAppFromManifest().catch((error) => {
+        console.error("Failed to bootstrap the application:", error);
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the compiled application bundle from the Vite manifest when it is available
- fall back to the development entry point when the manifest is missing so local dev keeps working

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9cae29ed48326be96a23ce4dc1c9d